### PR TITLE
Bugfix - Empty value was not detected 

### DIFF
--- a/Observer/ActionPredispatch.php
+++ b/Observer/ActionPredispatch.php
@@ -95,7 +95,7 @@ class ActionPredispatch implements \Magento\Framework\Event\ObserverInterface
             return $this;
         }
 
-        if ($this->request->getParam('hs_hid') !== '') {
+        if (!empty($this->request->getParam('hs_hid'))) {
             $this->processError();
         }
     }


### PR DESCRIPTION
The value for the hidden input with name **hs_hid** was incorrectly detected as non empty and the form was throwing an error.

Fixes issue #5. 